### PR TITLE
PR #3 (add/shortcode-handler)

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -104,6 +104,7 @@ function delete_rewrite_rules() {
 function autoload_files() {
 	$files = [
 		'post-type-registrar.php',
+		'shortcode.php',
 	];
 
 	foreach ( $files as $file ) {

--- a/src/config/product-post-type.php
+++ b/src/config/product-post-type.php
@@ -54,10 +54,9 @@ return [
 			'author',
 			'post-formats',
 		],
-		// Uncomment code below to activate feature.
-//		'additional'     => [
-//			'page-attributes',
-//		],
+		'additional'     => [
+			/*'page-attributes',*/
+		],
 	],
 
 	/**==============================================================

--- a/src/post-type-registrar.php
+++ b/src/post-type-registrar.php
@@ -28,7 +28,7 @@ add_action( 'init', __NAMESPACE__ . '\register_custom_post_types' );
  */
 function register_custom_post_types() {
 	// Load the configurations.
-	$configs = require_once _get_plugin_directory() . '/config/custom-post-types.php';
+	$configs = require_once _get_plugin_directory() . '/src/config/custom-post-types.php';
 	if ( ! is_array( $configs ) || empty( $configs ) ) {
 		return false;
 	}

--- a/src/shortcode.php
+++ b/src/shortcode.php
@@ -15,19 +15,17 @@ namespace spiralWebDB\Sandhills;
  *
  * @since 1.0.0
  */
-add_shortcode( 'feature' , __NAMESPACE__ . '\process_feature_shortcode' );
+add_shortcode( 'feature' , __NAMESPACE__ . '\process_product_feature_shortcode' );
 
 /*
  * Processing callback for the [feature] shortcode.
  *
  * @since 1.0.0.
  */
-function process_feature_shortcode() {
+function process_product_feature_shortcode() {
 
 	ob_start();
 	include '/view/shortcode.php';
 	ob_get_clean();
 }
 
-global $shortcode_tags;
-dump( $shortcode_tags );

--- a/src/shortcode.php
+++ b/src/shortcode.php
@@ -27,7 +27,9 @@ function process_product_feature_shortcode() {
 
 	ob_start();
 	include __DIR__ . '/view/shortcode.php';
-	ob_get_clean();
+	$output = ob_get_clean();
+
+	echo $output;
 }
 
 /*

--- a/src/shortcode.php
+++ b/src/shortcode.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ *  Shortcode handler.
+ *
+ * @package    spiralWebDB\Sandhills
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+namespace spiralWebDB\Sandhills;
+
+/*
+ * Register a WordPress shortcode
+ *
+ * @since 1.0.0
+ */
+add_shortcode( 'feature' , __NAMESPACE__ . '\process_feature_shortcode' );
+
+/*
+ * Processing callback for the [feature] shortcode.
+ *
+ * @since 1.0.0.
+ */
+function process_feature_shortcode() {
+
+	ob_start();
+	include '/view/shortcode.php';
+	ob_get_clean();
+}
+
+global $shortcode_tags;
+dump( $shortcode_tags );

--- a/src/shortcode.php
+++ b/src/shortcode.php
@@ -25,7 +25,7 @@ add_shortcode( 'feature' , __NAMESPACE__ . '\process_product_feature_shortcode' 
 function process_product_feature_shortcode() {
 
 	ob_start();
-	include '/view/shortcode.php';
+	include __DIR__ . '/view/shortcode.php';
 	ob_get_clean();
 }
 

--- a/src/shortcode.php
+++ b/src/shortcode.php
@@ -8,6 +8,7 @@
  * @link       http://spiralwebdb.com
  * @license    GNU General Public License 2.0+
  */
+
 namespace spiralWebDB\Sandhills;
 
 /*
@@ -15,7 +16,7 @@ namespace spiralWebDB\Sandhills;
  *
  * @since 1.0.0
  */
-add_shortcode( 'feature' , __NAMESPACE__ . '\process_product_feature_shortcode' );
+add_shortcode( 'feature', __NAMESPACE__ . '\process_product_feature_shortcode' );
 
 /*
  * Processing callback for the [feature] shortcode.
@@ -29,3 +30,18 @@ function process_product_feature_shortcode() {
 	ob_get_clean();
 }
 
+/*
+ * Call remote IP address.
+ *
+ * @since 1.0.0
+ * @return string $address  The IP address returned by the http GET request.
+ */
+function get_remote_ip_address() {
+	$url      = 'http://bot.whatismyipaddress.com/';
+	$response = wp_remote_get( $url );
+	$address  = $response['body'];
+
+	return $address;
+}
+
+get_remote_ip_address();

--- a/src/view/shortcode.php
+++ b/src/view/shortcode.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ *  View file for the registered shortcode.
+ *
+ * @package    spiralWebDB\Sandhills;
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+namespace spiralWebDB\Sandhills;
+?>
+<p>You called the shortcode view file.</p>

--- a/src/view/shortcode.php
+++ b/src/view/shortcode.php
@@ -1,13 +1,7 @@
 <?php
 /**
  *  View file for the registered shortcode.
- *
- * @package    spiralWebDB\Sandhills;
- * @since      1.0.0
- * @author     Robert A. Gadon
- * @link       http://spiralwebdb.com
- * @license    GNU General Public License 2.0+
  */
 namespace spiralWebDB\Sandhills;
 ?>
-<p>You called the shortcode view file.</p>
+<p>The caller's IP address is: <?php echo get_remote_ip_address(); ?></p>


### PR DESCRIPTION
## PR Summary

1. Add a shortcode handler to the `/src` directory. Register a `[feature]` shortcode with WordPress. 

2. Process the shortcode with PHP's output buffer and echo the output through the view file.  

3. Add a function to make a remote GET request to the URL 'http://bot.whatismyipaddress.com/' that returns the caller's IP address, and invoke the function.

4. Add a view file to render the shortcode HTML and caller's IP address. 